### PR TITLE
Add Linux-specific platform dependencies to `Gemfile.lock`

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,12 +3,12 @@ class HomeController < ApplicationController
   # before_action :set_home, only: %i[show edit update destroy ]
 
   def index
-    #@homes = Home.all.order('created_at DESC')
-    #@totals_deposits = {}
-    #@totals_credits = {}
-    #@totals_returns = {}
+    # @homes = Home.all.order('created_at DESC')
+    # @totals_deposits = {}
+    # @totals_credits = {}
+    # @totals_returns = {}
 
-    #@homes.each do |home|
+    # @homes.each do |home|
     #  next unless home.document.attached?
 
     #  Tempfile.create(['uploaded_file', ".#{home.document.filename.extension}"]) do |tempfile|

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,56 +3,56 @@ class HomeController < ApplicationController
   # before_action :set_home, only: %i[show edit update destroy ]
 
   def index
-    @homes = Home.all.order('created_at DESC')
-    @totals_deposits = {}
-    @totals_credits = {}
-    @totals_returns = {}
+    #@homes = Home.all.order('created_at DESC')
+    #@totals_deposits = {}
+    #@totals_credits = {}
+    #@totals_returns = {}
 
-    @homes.each do |home|
-      next unless home.document.attached?
+    #@homes.each do |home|
+    #  next unless home.document.attached?
 
-      Tempfile.create(['uploaded_file', ".#{home.document.filename.extension}"]) do |tempfile|
-        content = home.document.download.force_encoding('UTF-8')
-        tempfile.write(content)
-        tempfile.rewind
+    #  Tempfile.create(['uploaded_file', ".#{home.document.filename.extension}"]) do |tempfile|
+    #    content = home.document.download.force_encoding('UTF-8')
+    #    tempfile.write(content)
+    #    tempfile.rewind
 
-        spreadsheet = case home.document.filename.extension
-                      when 'csv' then Roo::CSV.new(tempfile.path)
-                      when 'xls' then Roo::Excel.new(tempfile.path)
-                      when 'xlsx' then Roo::Excelx.new(tempfile.path)
-                      end
+    #    spreadsheet = case home.document.filename.extension
+    #                  when 'csv' then Roo::CSV.new(tempfile.path)
+    #                  when 'xls' then Roo::Excel.new(tempfile.path)
+    #                  when 'xlsx' then Roo::Excelx.new(tempfile.path)
+    #                  end
 
-        header = spreadsheet.row(1)
-        deposits = []
-        credits = []
-        returns = []
+    #    header = spreadsheet.row(1)
+    #     deposits = []
+    #    credits = []
+    #    returns = []
 
-        (2..spreadsheet.last_row).each do |i|
-          row = [header, spreadsheet.row(i)].transpose.to_h
-          next unless row['type'] && row['amount']
+    #    (2..spreadsheet.last_row).each do |i|
+    #      row = [header, spreadsheet.row(i)].transpose.to_h
+    #      next unless row['type'] && row['amount']
 
-          case row['type']&.strip&.downcase
-          when 'deposit'
-            deposits << row
-          when 'credit'
-            credits << row
-          when 'return'
-            returns << row
-          end
-        end
+    #       case row['type']&.strip&.downcase
+    #      when 'deposit'
+    #        deposits << row
+    #      when 'credit'
+    #        credits << row
+    #       when 'return'
+    #         returns << row
+    #      end
+    #    end
 
-        @totals_deposits[home.id] = deposits.sum { |d| d['amount'].to_f }
-        @totals_credits[home.id] = credits.sum { |c| c['amount'].to_f }
-        @totals_returns[home.id] = returns.sum { |r| r['amount'].to_f }
-        @total_deposits_sum = @totals_deposits.values.sum
-        @total_credits_sum = @totals_credits.values.sum
-        @total_returns_sum = @totals_returns.values.sum
-      end
-    rescue StandardError
-      @totals_deposits[home.id] = 0
-      @totals_credits[home.id] = 0
-      @totals_returns[home.id] = 0
-    end
+    #    @totals_deposits[home.id] = deposits.sum { |d| d['amount'].to_f }
+    #    @totals_credits[home.id] = credits.sum { |c| c['amount'].to_f }
+    #     @totals_returns[home.id] = returns.sum { |r| r['amount'].to_f }
+    #     @total_deposits_sum = @totals_deposits.values.sum
+    #    @total_credits_sum = @totals_credits.values.sum
+    #    @total_returns_sum = @totals_returns.values.sum
+    #  end
+    # rescue StandardError
+    #  @totals_deposits[home.id] = 0
+    #  @totals_credits[home.id] = 0
+    #  @totals_returns[home.id] = 0
+    # end
   end
 
   def new

--- a/db/migrate/20250806114208_create_homes.rb
+++ b/db/migrate/20250806114208_create_homes.rb
@@ -1,9 +1,0 @@
-class CreateHomes < ActiveRecord::Migration[8.0]
-  def change
-    create_table :homes do |t|
-      t.string :name
-
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20250810103713_homes.rb
+++ b/db/migrate/20250810103713_homes.rb
@@ -1,0 +1,9 @@
+class Homes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :homes, id: :uuid  do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_09_165543) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_10_103713) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -41,7 +41,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_09_165543) do
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
-  
+
+  create_table "homes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false


### PR DESCRIPTION
- Included Linux-specific versions of `bcrypt_pbkdf`, `nokogiri`, `pg`, `tailwindcss-ruby`, and `thruster`.
- Updated `PLATFORMS` section to include `x86_64-linux` for broader compatibility.
This pull request makes significant changes to how the `homes` table is managed in the database and temporarily disables logic in the `HomeController#index` action. The migration for creating the `homes` table is updated to use UUIDs as primary keys, and the schema is updated accordingly. Additionally, the code in the controller responsible for processing and summarizing document data is commented out, likely for debugging or refactoring purposes.

**Database schema and migration updates:**

* Removed the old migration `20250806114208_create_homes.rb` that created the `homes` table with a default integer primary key.
* Added a new migration `20250810103713_homes.rb` to create the `homes` table with a UUID primary key.
* Updated `db/schema.rb` to reflect the new `homes` table with a UUID primary key and to match the latest migration version. [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R45-R50)

**Controller logic changes:**

* Commented out all logic in the `HomeController#index` action that was responsible for loading homes and calculating totals from attached documents. This code is now inactive, which may affect the index view's functionality.