### PR TITLE
Update Sentry DSN in initializer for new project configuration

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,8 +1,9 @@
 Sentry.init do |config|
-  config.dsn = 'https://2b4d1adaf9a79d33aca4892fd3ed72d4@o4507601057808384.ingest.de.sentry.io/4509790950064208'
+  config.dsn = 'https://130aeded055c1ce973d044dcee1abff5@o4507601057808384.ingest.de.sentry.io/4509790951178320'
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
   # Add data like request headers and IP for users,
   # see https://docs.sentry.io/platforms/ruby/data-management/data-collected/ for more info
   config.send_default_pii = true
 end
+


### PR DESCRIPTION
This pull request updates the Sentry configuration to use a new DSN (Data Source Name). This change ensures that error reporting is sent to the correct Sentry project.

- Updated the Sentry DSN in `config/initializers/sentry.rb` to point to a new Sentry project.